### PR TITLE
Sm/dash-h

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sf-plugin",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "engines": {
     "node": ">=14.16.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { noDuplicateShortCharacters } from './rules/noDuplicateShortCharacters';
+import { flagMinMaxDefault } from './rules/flagMinMaxDefault';
 import { flagSummary } from './rules/flagSummary';
 import { flagCasing } from './rules/flagCasing';
 import { extractMessageFlags } from './rules/extractMessageFlags';
@@ -28,6 +29,7 @@ export = {
         'sf-plugin/no-hardcoded-messages-commands': 'warn',
         'sf-plugin/flag-cross-references': 'error',
         'sf-plugin/json-flag': 'error',
+        'sf-plugin/flag-min-max-default': 'warn',
       },
     },
   },
@@ -41,5 +43,6 @@ export = {
     'command-summary': commandSummary,
     'command-example': commandExamples,
     'json-flag': jsonFlag,
+    'flag-min-max-default': flagMinMaxDefault,
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { commandSummary } from './rules/commandSummary';
 import { commandExamples } from './rules/commandExamples';
 import { extractMessageCommand } from './rules/extractMessageCommand';
 import { jsonFlag } from './rules/jsonFlag';
+import { dashH } from './rules/dash-h';
 
 export = {
   configs: {
@@ -23,6 +24,7 @@ export = {
         'sf-plugin/command-summary': 'error',
         'sf-plugin/command-example': 'warn',
         'sf-plugin/no-duplicate-short-characters': 'error',
+        'sf-plugin/no-h-short-char': 'error',
         'sf-plugin/flag-case': 'error',
         'sf-plugin/flag-summary': 'error',
         'sf-plugin/no-hardcoded-messages-flags': 'warn',
@@ -34,6 +36,7 @@ export = {
     },
   },
   rules: {
+    'no-h-short-char': dashH,
     'no-duplicate-short-characters': noDuplicateShortCharacters,
     'flag-case': flagCasing,
     'flag-summary': flagSummary,

--- a/src/rules/dash-h.ts
+++ b/src/rules/dash-h.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ESLintUtils, AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { ancestorsContainsSfCommand, isInCommandDirectory } from '../shared/commands';
+import { flagPropertyIsNamed, isFlag } from '../shared/flags';
+
+export const dashH = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'do not allow creation of a flag with short char -h',
+      recommended: 'error',
+    },
+    messages: {
+      message: '-h is reserved for help.  Choose a different short character',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      Property(node): void {
+        // is a flag
+        if (isInCommandDirectory(context) && isFlag(node) && ancestorsContainsSfCommand(context.getAncestors())) {
+          if (
+            node.value?.type === 'CallExpression' &&
+            node.value.arguments?.[0]?.type === 'ObjectExpression' &&
+            node.value.arguments[0].properties.find(
+              (property) =>
+                property.type === 'Property' &&
+                flagPropertyIsNamed(property, 'char') &&
+                property.value.type === AST_NODE_TYPES.Literal &&
+                property.value.value === 'h'
+            )
+          ) {
+            context.report({
+              node,
+              messageId: 'message',
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/rules/flagMinMaxDefault.ts
+++ b/src/rules/flagMinMaxDefault.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { ancestorsContainsSfCommand, isInCommandDirectory } from '../shared/commands';
+import { flagPropertyIsNamed, isFlag } from '../shared/flags';
+
+export const flagMinMaxDefault = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'Enforce that flags with min/max values have a default value',
+      recommended: 'warn',
+    },
+    messages: {
+      message: 'If your flag has a min or max value, it should have a default value.  Otherwise, it will be undefined',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      Property(node): void {
+        if (isInCommandDirectory(context) && isFlag(node) && ancestorsContainsSfCommand(context.getAncestors())) {
+          if (
+            node.value?.type === 'CallExpression' &&
+            node.value.arguments?.[0]?.type === 'ObjectExpression' &&
+            // has min/max
+            node.value.arguments[0].properties.some(
+              (property) =>
+                property.type === 'Property' &&
+                (flagPropertyIsNamed(property, 'min') || flagPropertyIsNamed(property, 'max'))
+            ) &&
+            !node.value.arguments[0].properties.some(
+              (property) => property.type === 'Property' && flagPropertyIsNamed(property, 'default')
+            )
+          ) {
+            context.report({
+              node,
+              messageId: 'message',
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/rules/jsonFlag.ts
+++ b/src/rules/jsonFlag.ts
@@ -6,7 +6,7 @@
  */
 import { ESLintUtils } from '@typescript-eslint/utils';
 import { ancestorsContainsSfCommand, isInCommandDirectory } from '../shared/commands';
-import { flagPropertyIsNamed, isFlag } from '../shared/flags';
+import { isFlag } from '../shared/flags';
 
 export const jsonFlag = ESLintUtils.RuleCreator.withoutDocs({
   meta: {

--- a/src/rules/noDuplicateShortCharacters.ts
+++ b/src/rules/noDuplicateShortCharacters.ts
@@ -6,7 +6,7 @@
  */
 import { ESLintUtils, AST_NODE_TYPES } from '@typescript-eslint/utils';
 import { ancestorsContainsSfCommand, isInCommandDirectory } from '../shared/commands';
-import { isFlagsStaticProperty, resolveFlagName } from '../shared/flags';
+import { isFlagsStaticProperty, resolveFlagName, flagPropertyIsNamed } from '../shared/flags';
 
 export const noDuplicateShortCharacters = ESLintUtils.RuleCreator.withoutDocs({
   meta: {
@@ -38,12 +38,10 @@ export const noDuplicateShortCharacters = ESLintUtils.RuleCreator.withoutDocs({
               flag.type === 'Property' &&
               flag.value.type === 'CallExpression' &&
               flag.value.arguments?.[0]?.type === AST_NODE_TYPES.ObjectExpression &&
-              flag.value.arguments?.[0]?.properties.some(
-                (p) => p.type === 'Property' && p.key.type === AST_NODE_TYPES.Identifier && p.key.name === 'char'
-              )
+              flag.value.arguments?.[0]?.properties.some((p) => p.type === 'Property' && flagPropertyIsNamed(p, 'char'))
             ) {
               const charNode = flag.value.arguments[0].properties.find(
-                (p) => p.type === 'Property' && p.key.type === AST_NODE_TYPES.Identifier && p.key.name === 'char'
+                (p) => p.type === 'Property' && flagPropertyIsNamed(p, 'char')
               );
               if (charNode.type === 'Property' && charNode.value.type === AST_NODE_TYPES.Literal) {
                 const char = charNode.value.raw;

--- a/test/rules/dash-h.test.ts
+++ b/test/rules/dash-h.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'path';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { dashH } from '../../src/rules/dash-h';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('dashH', dashH, {
+  valid: [
+    {
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    alias: Flags.string({
+      summary: 'foo',
+      char: 'a'
+    }),
+  }
+}
+
+`,
+    },
+    {
+      filename: path.normalize('foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    json: Flags.boolean({
+      char: 'h'
+    }),
+  }
+}
+
+`,
+    },
+  ],
+  invalid: [
+    {
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [{ messageId: 'message' }],
+      code: `
+export default class EnvCreateScratch extends SfCommand<Foo> {
+  public static flags = {
+    json: Flags.boolean({
+      char: 'h'
+    }),
+  }
+}
+`,
+    },
+  ],
+});

--- a/test/rules/flagMinMaxDefault.test.ts
+++ b/test/rules/flagMinMaxDefault.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'path';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { flagMinMaxDefault } from '../../src/rules/flagMinMaxDefault';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('flagMinMaxDefault', flagMinMaxDefault, {
+  valid: [
+    {
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    alias: Flags.integer({
+      min: 1,
+      max: 5,
+      default: 2
+    })
+  }
+}
+
+`,
+    },
+
+    {
+      filename: path.normalize('foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    alias: Flags.integer({
+      min: 1,
+      max: 5
+    }),
+  }
+}
+
+`,
+    },
+  ],
+  invalid: [
+    {
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [
+        {
+          messageId: 'message',
+          data: { flagName: 'Alias' },
+        },
+      ],
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: Flags.integer({
+      min: 5
+    }),
+  }
+}
+`,
+    },
+    {
+      errors: [
+        {
+          messageId: 'message',
+        },
+      ],
+      filename: path.normalize('src/commands/foo.ts'),
+
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: Flags.integer({
+      max: 5
+    }),
+  }
+}
+`,
+    },
+    {
+      errors: [
+        {
+          messageId: 'message',
+        },
+      ],
+      filename: path.normalize('src/commands/foo.ts'),
+
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: Flags.integer({
+      min: 3,
+      max: 5
+    }),
+  }
+}
+`,
+    },
+  ],
+});


### PR DESCRIPTION
prevent using `-h` on flags to protect sf's help behavior
@W-11486833@

warns user to add a default if using min/max

also 1.0 release to fix tags/release issue (I don't think the `halt` step likes `0.` releases)