### PR TITLE
Sm/defaultValue-on-duration

### DIFF
--- a/src/rules/flagMinMaxDefault.ts
+++ b/src/rules/flagMinMaxDefault.ts
@@ -35,7 +35,10 @@ export const flagMinMaxDefault = ESLintUtils.RuleCreator.withoutDocs({
                 (flagPropertyIsNamed(property, 'min') || flagPropertyIsNamed(property, 'max'))
             ) &&
             !node.value.arguments[0].properties.some(
-              (property) => property.type === 'Property' && flagPropertyIsNamed(property, 'default')
+              (property) =>
+                property.type === 'Property' &&
+                // defaultValue for DurationFlags
+                (flagPropertyIsNamed(property, 'default') || flagPropertyIsNamed(property, 'defaultValue'))
             )
           ) {
             context.report({

--- a/test/rules/commandExample.test.ts
+++ b/test/rules/commandExample.test.ts
@@ -14,8 +14,8 @@ const ruleTester = new ESLintUtils.RuleTester({
 
 ruleTester.run('commandExamples', commandExamples, {
   valid: [
-    // example with different chars
     {
+      name: 'correct example for a command',
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static readonly summary = 'foo'
@@ -24,16 +24,16 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // not an sfCommand
     {
+      name: 'not an sf command',
       code: `
 export default class EnvCreateScratch extends somethingElse<ScratchCreateResponse> {
   // stuff
 }
 `,
     },
-    // violation but in wrong folder
     {
+      name: 'not in the commands folder',
       filename: path.normalize('foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -45,6 +45,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'is missing examples',
       filename: path.normalize('src/commands/foo.ts'),
       errors: [
         {

--- a/test/rules/commandSummary.test.ts
+++ b/test/rules/commandSummary.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('commandSummary', commandSummary, {
   valid: [
     {
+      name: 'correct summary for a command',
       filename: path.normalize('src/commands/foo.ts'),
       code:
         // example with different chars
@@ -26,8 +27,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // not an sfCommand
     {
+      name: 'not an sf command',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends somethingElse<ScratchCreateResponse> {
@@ -35,8 +36,8 @@ export default class EnvCreateScratch extends somethingElse<ScratchCreateRespons
 }
 `,
     },
-    // not an command class
     {
+      name: 'not an sf command',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export abstract class StagedProgress<T> {
@@ -45,8 +46,8 @@ export abstract class StagedProgress<T> {
 }
   `,
     },
-    // not an command directory
     {
+      name: 'not in the command directory',
       filename: path.normalize('src/shared/.ts'),
       code: `
 export abstract class StagedProgress<T> {
@@ -58,6 +59,7 @@ export abstract class StagedProgress<T> {
   ],
   invalid: [
     {
+      name: 'is missing summary',
       errors: [
         {
           messageId: 'summary',

--- a/test/rules/dash-h.test.ts
+++ b/test/rules/dash-h.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('dashH', dashH, {
   valid: [
     {
+      name: 'does not use -h',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -29,6 +30,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'not in commands directory',
       filename: path.normalize('foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -44,6 +46,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'uses -h',
       filename: path.normalize('src/commands/foo.ts'),
       errors: [{ messageId: 'message' }],
       code: `

--- a/test/rules/duplicateChars.test.ts
+++ b/test/rules/duplicateChars.test.ts
@@ -14,8 +14,8 @@ const ruleTester = new ESLintUtils.RuleTester({
 
 ruleTester.run('no duplicate short characters', noDuplicateShortCharacters, {
   valid: [
-    // example with different chars
     {
+      name: 'all flags use different chars',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -31,8 +31,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 
 `,
     },
-    // example with some chars not present
     {
+      name: 'some flags have no char',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -48,8 +48,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
 
-    // bad but not in commands directory
     {
+      name: 'not in commands dir',
       filename: path.normalize('src/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -68,6 +68,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'repeated -a',
       errors: [
         {
           messageId: 'message',

--- a/test/rules/extractMessage.test.ts
+++ b/test/rules/extractMessage.test.ts
@@ -14,8 +14,8 @@ const ruleTester = new ESLintUtils.RuleTester({
 
 ruleTester.run('no duplicate short characters', extractMessageFlags, {
   valid: [
-    // no messages is fine
     {
+      name: 'no messages',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -27,8 +27,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // summary only
     {
+      name: 'summary uses messages',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -41,6 +41,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'summary and description use messages',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -54,6 +55,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'description uses messages',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -65,8 +67,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // all sorts of violations but not in the commands directory
     {
+      name: 'not in commands dir',
       filename: path.normalize('src/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -82,8 +84,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'hardcoded summary',
       filename: path.normalize('src/commands/foo.ts'),
-
       errors: [
         {
           messageId: 'message',
@@ -100,6 +102,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'hardcoded description',
       errors: [
         {
           messageId: 'message',
@@ -118,6 +121,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: '2 errors when both are hardcoded',
       errors: [
         {
           messageId: 'message',

--- a/test/rules/extractMessageCommand.test.ts
+++ b/test/rules/extractMessageCommand.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('no hardcoded summary/description on command', extractMessageCommand, {
   valid: [
     {
+      name: 'messages for command description and summary',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -23,8 +24,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // description only
     {
+      name: 'messages for command description',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -32,8 +33,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // summary only
     {
+      name: 'messages for command summary',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -41,8 +42,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // not an sf command
     {
+      name: 'not an sf command',
       filename: path.normalize('src/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SomethingElse<ScratchCreateResponse> {
@@ -51,8 +52,8 @@ export default class EnvCreateScratch extends SomethingElse<ScratchCreateRespons
 }
 `,
     },
-    // all sorts of violations but not in the commands directory
     {
+      name: 'not in the commands folder',
       filename: path.normalize('src/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -64,8 +65,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'summary uses messages but description does not',
       filename: path.normalize('src/commands/foo.ts'),
-
       errors: [
         {
           messageId: 'message',
@@ -79,6 +80,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: '2 errors when neither uses messages',
       errors: [
         {
           messageId: 'message',

--- a/test/rules/flagCasing.test.ts
+++ b/test/rules/flagCasing.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('flagCasing', flagCasing, {
   valid: [
     {
+      name: 'correct flag casing for hyphenated and non-hyphenated',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -25,8 +26,8 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // wrong case but not in commands directory
     {
+      name: 'not in commands directory',
       filename: path.normalize('src/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -40,6 +41,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'capitalized non-hyphenated flag',
       errors: [
         {
           messageId: 'message',
@@ -65,6 +67,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'both flags are capitalized incorrectly',
       errors: [
         {
           messageId: 'message',

--- a/test/rules/flagCrossReferences.test.ts
+++ b/test/rules/flagCrossReferences.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('cross-references exist for dependsOn, exclusive, exactlyOne', flagCrossReferences, {
   valid: [
     {
+      name: 'dependent flag exists',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -27,8 +28,9 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // non static other definition of flags
     {
+      name: 'non-static definition of flags is supported',
+      filename: path.normalize('src/commands/foo.ts'),
       code: `
     export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static flags = {
@@ -42,6 +44,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: '2 exclusive flags that refer to each other',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -57,6 +60,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: '2 exactlyOne flags that refer to each other',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -71,10 +75,9 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 }
 `,
     },
-    // would be invalid except not in commands folder
     {
       filename: path.normalize('src/foo.ts'),
-
+      name: 'anything is ok outside the commands directory',
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static flags = {
@@ -88,6 +91,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'exclusive refers to non-existent flag',
       errors: [
         {
           messageId: 'missingFlag',
@@ -108,6 +112,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'dependsOn refers to non-existent flag',
       errors: [
         {
           messageId: 'missingFlag',
@@ -127,6 +132,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'exactlyOne refers to non-existent flag',
       errors: [
         {
           messageId: 'missingFlag',

--- a/test/rules/flagMinMaxDefault.test.ts
+++ b/test/rules/flagMinMaxDefault.test.ts
@@ -67,6 +67,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'missing default',
       filename: path.normalize('src/commands/foo.ts'),
       errors: [
         {
@@ -84,6 +85,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'missing defaultValue on a duratino flag',
       filename: path.normalize('src/commands/foo.ts'),
       errors: [
         {

--- a/test/rules/flagMinMaxDefault.test.ts
+++ b/test/rules/flagMinMaxDefault.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('flagMinMaxDefault', flagMinMaxDefault, {
   valid: [
     {
+      name: 'has min, max, default',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -31,6 +32,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
     },
 
     {
+      name: 'not commands directory',
       filename: path.normalize('foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -47,6 +49,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 
     // duration flags use defaultValue instead of default
     {
+      name: 'correct setup for a Duration flag',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {

--- a/test/rules/flagMinMaxDefault.test.ts
+++ b/test/rules/flagMinMaxDefault.test.ts
@@ -44,6 +44,23 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 
 `,
     },
+
+    // duration flags use defaultValue instead of default
+    {
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    alias: Flags.duration({
+      min: 1,
+      max: 5,
+      defaultValue: 2
+    }),
+  }
+}
+
+`,
+    },
   ],
   invalid: [
     {
@@ -51,13 +68,29 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
       errors: [
         {
           messageId: 'message',
-          data: { flagName: 'Alias' },
         },
       ],
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static flags = {
     foo: Flags.integer({
+      min: 5
+    }),
+  }
+}
+`,
+    },
+    {
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [
+        {
+          messageId: 'message',
+        },
+      ],
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: Flags.duration({
       min: 5
     }),
   }

--- a/test/rules/flagSummary.test.ts
+++ b/test/rules/flagSummary.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('flagSummary', flagSummary, {
   valid: [
     {
+      name: 'flag with a summary',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -29,6 +30,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
     },
 
     {
+      name: 'not in commands directory',
       filename: path.normalize('foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -42,6 +44,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'no summary',
       filename: path.normalize('src/commands/foo.ts'),
       errors: [
         {
@@ -60,6 +63,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: '2 flags missing their summary',
       errors: [
         {
           messageId: 'message',

--- a/test/rules/jsonFlag.test.ts
+++ b/test/rules/jsonFlag.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run('jsonFlag', jsonFlag, {
   valid: [
     {
+      name: 'flags without json',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -28,6 +29,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'not in command directory',
       filename: path.normalize('foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
@@ -41,6 +43,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
+      name: 'has a flag named "json"',
       filename: path.normalize('src/commands/foo.ts'),
       errors: [{ messageId: 'message' }],
       code: `


### PR DESCRIPTION
1. support the defaultValue (instead of default) to avoid false positives on Duration flags
2. gives names to test cases for clarity
3. retries the git tag automation (I forgot to set the bot's ssh keys on the project)