### PR TITLE
fix: check for ClassProperty type

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "LICENSE.txt"
   ],
   "dependencies": {
-    "@typescript-eslint/utils": "^5.27.1"
+    "@typescript-eslint/utils": "^5.36.1"
   },
   "devDependencies": {
     "@salesforce/prettier-config": "^0.0.2",

--- a/src/shared/commands.ts
+++ b/src/shared/commands.ts
@@ -18,8 +18,18 @@ export const ancestorsContainsSfCommand = (ancestors: TSESTree.Node[]): boolean 
 export const extendsSfCommand = (node: TSESTree.ClassDeclaration): boolean =>
   node.superClass?.type === AST_NODE_TYPES.Identifier && node.superClass.name === 'SfCommand';
 
-export const getClassPropertyIdentifierName = (node: TSESTree.ClassElement): string =>
-  node.type === 'PropertyDefinition' && node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : undefined;
+export const getClassPropertyIdentifierName = (node: TSESTree.ClassElement): string | null => {
+  if (node.type === AST_NODE_TYPES.PropertyDefinition && node.key.type === AST_NODE_TYPES.Identifier) {
+    return node.key.name;
+    // @ts-expect-error because ClassProperty isn't type but it's a valid type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  } else if (node.type === 'ClassProperty' && node.key.type === AST_NODE_TYPES.Identifier) {
+    // @ts-expect-error because ClassProperty isn't type but it's a valid type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return node.key.name as string;
+  }
+  return null;
+};
 
 // we don't care what the types are, really any context will do
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/shared/commands.ts
+++ b/src/shared/commands.ts
@@ -21,12 +21,12 @@ export const extendsSfCommand = (node: TSESTree.ClassDeclaration): boolean =>
 export const getClassPropertyIdentifierName = (node: TSESTree.ClassElement): string | null => {
   if (node.type === AST_NODE_TYPES.PropertyDefinition && node.key.type === AST_NODE_TYPES.Identifier) {
     return node.key.name;
-    // @ts-expect-error because ClassProperty isn't type but it's a valid type
+    // @ts-expect-error because ClassProperty isn't typed but it's a valid type
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   } else if (node.type === 'ClassProperty' && node.key.type === AST_NODE_TYPES.Identifier) {
-    // @ts-expect-error because ClassProperty isn't type but it's a valid type
+    // @ts-expect-error because ClassProperty isn't typed but it's a valid type
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return node.key.name as string;
+    return (node.key?.name as string) || null;
   }
   return null;
 };

--- a/test/rules/commandExample.test.ts
+++ b/test/rules/commandExample.test.ts
@@ -18,8 +18,8 @@ ruleTester.run('commandExamples', commandExamples, {
     {
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
-  public static readonly summary = 'foo'
-  public static readonly examples = 'baz'
+  public static readonly summary = message.getMessages('summary');
+  public static readonly examples = message.getMessages('examples');
 
 }
 `,

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,6 +860,14 @@
     "@typescript-eslint/types" "5.27.1"
     "@typescript-eslint/visitor-keys" "5.27.1"
 
+"@typescript-eslint/scope-manager@5.36.1":
+  version "5.36.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.36.1.tgz#23c49b7ddbcffbe09082e6694c2524950766513f"
+  integrity sha512-pGC2SH3/tXdu9IH3ItoqciD3f3RRGCh7hb9zPdN2Drsr341zgd6VbhP5OHQO/reUqihNltfPpMpTNihFMarP2w==
+  dependencies:
+    "@typescript-eslint/types" "5.36.1"
+    "@typescript-eslint/visitor-keys" "5.36.1"
+
 "@typescript-eslint/type-utils@5.27.1":
   version "5.27.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz#369f695199f74c1876e395ebea202582eb1d4166"
@@ -874,6 +882,11 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.27.1.tgz#34e3e629501349d38be6ae97841298c03a6ffbf1"
   integrity sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==
 
+"@typescript-eslint/types@5.36.1":
+  version "5.36.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.36.1.tgz#1cf0e28aed1cb3ee676917966eb23c2f8334ce2c"
+  integrity sha512-jd93ShpsIk1KgBTx9E+hCSEuLCUFwi9V/urhjOWnOaksGZFbTOxAT47OH2d4NLJnLhkVD+wDbB48BuaycZPLBg==
+
 "@typescript-eslint/typescript-estree@5.27.1":
   version "5.27.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz#7621ee78607331821c16fffc21fc7a452d7bc808"
@@ -887,7 +900,20 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.27.1", "@typescript-eslint/utils@^5.27.1":
+"@typescript-eslint/typescript-estree@5.36.1":
+  version "5.36.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.36.1.tgz#b857f38d6200f7f3f4c65cd0a5afd5ae723f2adb"
+  integrity sha512-ih7V52zvHdiX6WcPjsOdmADhYMDN15SylWRZrT2OMy80wzKbc79n8wFW0xpWpU0x3VpBz/oDgTm2xwDAnFTl+g==
+  dependencies:
+    "@typescript-eslint/types" "5.36.1"
+    "@typescript-eslint/visitor-keys" "5.36.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.27.1":
   version "5.27.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.27.1.tgz#b4678b68a94bc3b85bf08f243812a6868ac5128f"
   integrity sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==
@@ -899,12 +925,32 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/utils@^5.36.1":
+  version "5.36.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.36.1.tgz#136d5208cc7a3314b11c646957f8f0b5c01e07ad"
+  integrity sha512-lNj4FtTiXm5c+u0pUehozaUWhh7UYKnwryku0nxJlYUEWetyG92uw2pr+2Iy4M/u0ONMKzfrx7AsGBTCzORmIg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.36.1"
+    "@typescript-eslint/types" "5.36.1"
+    "@typescript-eslint/typescript-estree" "5.36.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@5.27.1":
   version "5.27.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz#05a62666f2a89769dac2e6baa48f74e8472983af"
   integrity sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==
   dependencies:
     "@typescript-eslint/types" "5.27.1"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.36.1":
+  version "5.36.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.36.1.tgz#7731175312d65738e501780f923896d200ad1615"
+  integrity sha512-ojB9aRyRFzVMN3b5joSYni6FAS10BBSCAfKJhjJAV08t/a95aM6tAhz+O1jF+EtgxktuSO3wJysp2R+Def/IWQ==
+  dependencies:
+    "@typescript-eslint/types" "5.36.1"
     eslint-visitor-keys "^3.3.0"
 
 acorn-jsx@^5.3.2:


### PR DESCRIPTION
Checks for `ClassProperty` type when checking for class property names.

For some reason the class properties in the tests return `PropertyIdentifier` but in the real world they're typed as `ClassProperty`, which isn't typed in `@typescript-eslint/utils`