### PR TITLE
feat: autofix this.flags inside run method

### DIFF
--- a/src/shared/commands.ts
+++ b/src/shared/commands.ts
@@ -32,15 +32,15 @@ export const isInCommandDirectory = (context: RuleContext<any, any>): boolean =>
   return context.getPhysicalFilename().includes(`src${sep}commands${sep}`); // not an sfCommand
 };
 
+export const isRunMethod = (node: TSESTree.Node): boolean =>
+  node.type === AST_NODE_TYPES.MethodDefinition &&
+  node.kind === 'method' &&
+  node.computed === false &&
+  node.accessibility === 'public' &&
+  node.static === false &&
+  node.override === false &&
+  node.key.type === AST_NODE_TYPES.Identifier &&
+  node.key.name === 'run';
+
 export const getRunMethod = (node: TSESTree.ClassDeclaration): TSESTree.ClassElement =>
-  node.body.body.find(
-    (b) =>
-      b.type === AST_NODE_TYPES.MethodDefinition &&
-      b.kind === 'method' &&
-      b.computed === false &&
-      b.accessibility === 'public' &&
-      b.static === false &&
-      b.override === false &&
-      b.key.type === AST_NODE_TYPES.Identifier &&
-      b.key.name === 'run'
-  );
+  node.body.body.find((b) => isRunMethod(b));

--- a/test/rules/migration/noThisFlags.test.ts
+++ b/test/rules/migration/noThisFlags.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'path';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { noThisFlags } from '../../../src/rules/migration/noThisFlags';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('noThisFlags', noThisFlags, {
+  valid: [
+    {
+      name: 'Custom Type',
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: flags.string({ char: 'f', description: 'foo flag' }),
+  }
+  public async run(): Promise<ScratchCreateResponse> {
+    const {flags} = await this.parse(EnvCreateScratch)
+    console.log(flags.foo)
+  }
+}
+`,
+    },
+    {
+      name: 'Not in commands dir',
+      filename: path.normalize('foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: flags.string({ char: 'f', description: 'foo flag' }),
+  }
+  public async run(): Promise<ScratchCreateResponse> {
+    const {flags} = await this.parse(EnvCreateScratch)
+    console.log(flags.foo)
+  }
+}
+`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'uses this.flags',
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [{ messageId: 'noThisFlags' }],
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: flags.string({ char: 'f', description: 'foo flag' }),
+  }
+  public async run(): Promise<ScratchCreateResponse> {
+    const {flags} = await this.parse(EnvCreateScratch)
+  }
+  public otherMethod() {
+    console.log(this.flags.foo)
+  }
+}
+`,
+    },
+    {
+      name: 'uses this.flags in run (autofix)',
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [{ messageId: 'noThisFlags' }],
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: flags.string({ char: 'f', description: 'foo flag' }),
+  }
+  public async run(): Promise<ScratchCreateResponse> {
+    const {flags} = await this.parse(EnvCreateScratch)
+    console.log(this.flags.foo)
+  }
+}
+`,
+      output: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    foo: flags.string({ char: 'f', description: 'foo flag' }),
+  }
+  public async run(): Promise<ScratchCreateResponse> {
+    const {flags} = await this.parse(EnvCreateScratch)
+    console.log(flags.foo)
+  }
+}
+`,
+    },
+  ],
+});


### PR DESCRIPTION
test coverage for this.flags

feat: `this.flags` inside the `run` method will be converted to `flags`.  Other methods will still offer the suggestions [skip-validate-pr]