### PR TITLE
fix: add filepath -> file conversion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { noTimeFlags } from './rules/migration/no-time-flags';
 import { idFlagSuggestions } from './rules/id-flag-suggestions';
 import { noIdFlags } from './rules/migration/no-id-flags';
 import { noFilepathFlags } from './rules/migration/no-filepath-flags';
+import { noNumberFlags } from './rules/migration/no-number-flags';
 
 const recommended = {
   plugins: ['sf-plugin'],
@@ -107,5 +108,6 @@ export = {
     'id-flag-suggestions': idFlagSuggestions,
     'no-id-flags': noIdFlags,
     'no-filepath-flags': noFilepathFlags,
+    'no-number-flags': noNumberFlags,
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { readOnlyProperties } from './rules/read-only-properties';
 import { noTimeFlags } from './rules/migration/no-time-flags';
 import { idFlagSuggestions } from './rules/id-flag-suggestions';
 import { noIdFlags } from './rules/migration/no-id-flags';
+import { noFilepathFlags } from './rules/migration/no-filepath-flags';
 
 const recommended = {
   plugins: ['sf-plugin'],
@@ -105,5 +106,6 @@ export = {
     'no-time-flags': noTimeFlags,
     'id-flag-suggestions': idFlagSuggestions,
     'no-id-flags': noIdFlags,
+    'no-filepath-flags': noFilepathFlags,
   },
 };

--- a/src/rules/migration/no-filepath-flags.ts
+++ b/src/rules/migration/no-filepath-flags.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+import { ancestorsContainsSfCommand, isInCommandDirectory } from '../../shared/commands';
+import { isFlag } from '../../shared/flags';
+
+export const noFilepathFlags = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'Change filepath flag to file flag',
+      recommended: 'error',
+    },
+    messages: {
+      message: 'filepath flags are not available on sfCommand.  Use file instead',
+    },
+    type: 'problem',
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    return isInCommandDirectory(context)
+      ? {
+          Property(node): void {
+            if (isFlag(node) && ancestorsContainsSfCommand(context.getAncestors())) {
+              if (
+                (node.key.type === AST_NODE_TYPES.Identifier || node.key.type === AST_NODE_TYPES.Literal) &&
+                node.value?.type === AST_NODE_TYPES.CallExpression &&
+                node.value.callee?.type === AST_NODE_TYPES.MemberExpression &&
+                node.value.callee.property?.type === AST_NODE_TYPES.Identifier &&
+                node.value.callee.property.name === 'filepath'
+              ) {
+                const toReplace = node.value.callee.property;
+                context.report({
+                  node: node.value.callee.property,
+                  messageId: 'message',
+                  fix: (fixer) => {
+                    return fixer.replaceText(toReplace, 'file');
+                  },
+                });
+              }
+            }
+          },
+        }
+      : {};
+  },
+});

--- a/src/rules/migration/no-number-flags.ts
+++ b/src/rules/migration/no-number-flags.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+import { ancestorsContainsSfCommand, isInCommandDirectory } from '../../shared/commands';
+import { isFlag } from '../../shared/flags';
+
+export const noNumberFlags = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'Change number flag to integer',
+      recommended: 'error',
+    },
+    messages: {
+      message: 'number flags are not available on sfCommand.  Use integer instead',
+    },
+    type: 'problem',
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    return isInCommandDirectory(context)
+      ? {
+          Property(node): void {
+            if (isFlag(node) && ancestorsContainsSfCommand(context.getAncestors())) {
+              if (
+                (node.key.type === AST_NODE_TYPES.Identifier || node.key.type === AST_NODE_TYPES.Literal) &&
+                node.value?.type === AST_NODE_TYPES.CallExpression &&
+                node.value.callee?.type === AST_NODE_TYPES.MemberExpression &&
+                node.value.callee.property?.type === AST_NODE_TYPES.Identifier &&
+                node.value.callee.property.name === 'number'
+              ) {
+                const toReplace = node.value.callee.property;
+                context.report({
+                  node: node.value.callee.property,
+                  messageId: 'message',
+                  fix: (fixer) => {
+                    return fixer.replaceText(toReplace, 'integer');
+                  },
+                });
+              }
+            }
+          },
+        }
+      : {};
+  },
+});

--- a/test/rules/migration/no-filepath-flags.test.ts
+++ b/test/rules/migration/no-filepath-flags.test.ts
@@ -6,21 +6,21 @@
  */
 import path from 'path';
 import { ESLintUtils } from '@typescript-eslint/utils';
-import { noIdFlags } from '../../../src/rules/migration/no-id-flags';
+import { noFilepathFlags } from '../../../src/rules/migration/no-filepath-flags';
 
 const ruleTester = new ESLintUtils.RuleTester({
   parser: '@typescript-eslint/parser',
 });
 
-ruleTester.run('noIdFlags', noIdFlags, {
+ruleTester.run('noFilepathFlags', noFilepathFlags, {
   valid: [
     {
-      name: 'salesforceId flag',
+      name: 'filepath flag',
       filename: path.normalize('src/commands/foo.ts'),
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static flags = {
-    verbose: Flags.salesforceId({
+    verbose: Flags.file({
       summary: 'foo'
     }),
   }
@@ -34,7 +34,7 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   public static flags = {
-    verbose: Flags.id({}),
+    verbose: Flags.filepath({}),
   }
 }
 
@@ -43,13 +43,13 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
   ],
   invalid: [
     {
-      name: 'id flag',
+      name: 'filepath flag',
       filename: path.normalize('src/commands/foo.ts'),
       errors: [{ messageId: 'message' }],
       code: `
 export default class EnvCreateScratch extends SfCommand<Foo> {
   public static flags = {
-    verbose: Flags.id({
+    verbose: Flags.filepath({
       summary: 'foo'
     }),
   }
@@ -58,7 +58,7 @@ export default class EnvCreateScratch extends SfCommand<Foo> {
       output: `
 export default class EnvCreateScratch extends SfCommand<Foo> {
   public static flags = {
-    verbose: Flags.salesforceId({
+    verbose: Flags.file({
       summary: 'foo'
     }),
   }

--- a/test/rules/migration/no-number-flags.test.ts
+++ b/test/rules/migration/no-number-flags.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'path';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { noNumberFlags } from '../../../src/rules/migration/no-number-flags';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('noNumberFlags', noNumberFlags, {
+  valid: [
+    {
+      name: 'integer flag',
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    verbose: Flags.integer({
+      summary: 'foo'
+    }),
+  }
+}
+
+`,
+    },
+    {
+      name: 'not in command directory',
+      filename: path.normalize('foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    verbose: Flags.integer({}),
+  }
+}
+
+`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'id flag',
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [{ messageId: 'message' }],
+      code: `
+export default class EnvCreateScratch extends SfCommand<Foo> {
+  public static flags = {
+    verbose: Flags.number({
+      summary: 'foo'
+    }),
+  }
+}
+`,
+      output: `
+export default class EnvCreateScratch extends SfCommand<Foo> {
+  public static flags = {
+    verbose: Flags.integer({
+      summary: 'foo'
+    }),
+  }
+}
+`,
+    },
+  ],
+});


### PR DESCRIPTION
[skip-validate-pr]

adds a rule to convert `flags.filepath` -> `flags.file` for `sfCommand`
adds a rule to convert `flags.number` -> `flags.integer` for `sfCommand`