### PR TITLE
fix: handle more potential nulls

### DIFF
--- a/src/rules/no-unnecessary-properties.ts
+++ b/src/rules/no-unnecessary-properties.ts
@@ -33,7 +33,7 @@ export const noUnnecessaryProperties = ESLintUtils.RuleCreator.withoutDocs({
               node.static &&
               node.key?.type === AST_NODE_TYPES.Identifier &&
               node.parent?.type === AST_NODE_TYPES.ClassBody &&
-              node.parent?.parent?.type === AST_NODE_TYPES.ClassDeclaration &&
+              node.parent.parent?.type === AST_NODE_TYPES.ClassDeclaration &&
               node.value &&
               extendsSfCommand(node.parent.parent)
             ) {

--- a/src/rules/no-unnecessary-properties.ts
+++ b/src/rules/no-unnecessary-properties.ts
@@ -39,7 +39,7 @@ export const noUnnecessaryProperties = ESLintUtils.RuleCreator.withoutDocs({
             ) {
               // properties that default to false
               if (
-                node.value?.type === AST_NODE_TYPES.Literal &&
+                node.value.type === AST_NODE_TYPES.Literal &&
                 falseProps.includes(node.key.name) &&
                 node.value.value === false
               ) {
@@ -52,7 +52,7 @@ export const noUnnecessaryProperties = ESLintUtils.RuleCreator.withoutDocs({
               }
               // properties that default to emptyArrays
               if (
-                node.value?.type === AST_NODE_TYPES.ArrayExpression &&
+                node.value.type === AST_NODE_TYPES.ArrayExpression &&
                 emptyProps.includes(node.key.name) &&
                 node.value.elements.length === 0
               ) {

--- a/src/rules/no-unnecessary-properties.ts
+++ b/src/rules/no-unnecessary-properties.ts
@@ -31,14 +31,15 @@ export const noUnnecessaryProperties = ESLintUtils.RuleCreator.withoutDocs({
           PropertyDefinition(node): void {
             if (
               node.static &&
-              node.key.type === AST_NODE_TYPES.Identifier &&
-              node.parent.type === AST_NODE_TYPES.ClassBody &&
-              node.parent.parent.type === AST_NODE_TYPES.ClassDeclaration &&
+              node.key?.type === AST_NODE_TYPES.Identifier &&
+              node.parent?.type === AST_NODE_TYPES.ClassBody &&
+              node.parent?.parent?.type === AST_NODE_TYPES.ClassDeclaration &&
+              node.value &&
               extendsSfCommand(node.parent.parent)
             ) {
               // properties that default to false
               if (
-                node.value.type === AST_NODE_TYPES.Literal &&
+                node.value?.type === AST_NODE_TYPES.Literal &&
                 falseProps.includes(node.key.name) &&
                 node.value.value === false
               ) {
@@ -51,7 +52,7 @@ export const noUnnecessaryProperties = ESLintUtils.RuleCreator.withoutDocs({
               }
               // properties that default to emptyArrays
               if (
-                node.value.type === AST_NODE_TYPES.ArrayExpression &&
+                node.value?.type === AST_NODE_TYPES.ArrayExpression &&
                 emptyProps.includes(node.key.name) &&
                 node.value.elements.length === 0
               ) {

--- a/test/rules/no-uneccessary-properties.test.ts
+++ b/test/rules/no-uneccessary-properties.test.ts
@@ -24,6 +24,14 @@ export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
 `,
     },
     {
+      name: 'other static properties with no value',
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static org: Org
+}
+`,
+    },
+    {
       name: 'populated aliases  for a command',
       code: `
 export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {


### PR DESCRIPTION
error from 
```
TypeError: Cannot read properties of null (reading 'type')
Occurred while linting /Users/peter.hale/alm-cli-git/plugin-packaging/src/commands/package/install/report.ts:29
Rule: "sf-plugin/no-unnecessary-properties"
```

Each property now has `?.type`, or another check to ensure it isn't null. 