### PR TITLE
feat: no-execCmd-double-quotes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,13 @@ import { noUnnecessaryAliases } from './rules/no-unnecessary-aliases';
 import { noMissingMessages } from './rules/no-missing-messages';
 import { noArgsParseWithoutStrictFalse } from './rules/no-args-parse-without-strict-false';
 import { noHyphenAliases } from './rules/no-hyphens-aliases';
+import { noExecCmdDoubleQuotes } from './rules/no-execCmd-double-quotes';
 
 const library = {
   plugins: ['sf-plugin'],
   rules: {
     'sf-plugin/no-missing-messages': 'error',
+    'sf-plugin/no-execcmd-double-quotes': 'error',
   },
 };
 
@@ -142,5 +144,6 @@ export = {
     'no-missing-messages': noMissingMessages,
     'no-args-parse-without-strict-false': noArgsParseWithoutStrictFalse,
     'no-hyphens-aliases': noHyphenAliases,
+    'no-execcmd-double-quotes': noExecCmdDoubleQuotes,
   },
 };

--- a/src/rules/no-execCmd-double-quotes.ts
+++ b/src/rules/no-execCmd-double-quotes.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+export const noExecCmdDoubleQuotes = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'Do not use double quotes in NUT examples.  They will not work on windows',
+      recommended: 'warn',
+    },
+    messages: {
+      message:
+        'Do not use double quotes in NUT examples.  They will not work on windows. Convert your execCmd to use single quotes',
+    },
+    type: 'problem',
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node): void {
+        if (node.callee.type === AST_NODE_TYPES.Identifier && node.callee.name === 'execCmd') {
+          if (
+            node.arguments[0].type === AST_NODE_TYPES.Literal &&
+            typeof node.arguments[0].value === 'string' &&
+            node.arguments[0].value.includes('"')
+          ) {
+            context.report({
+              node: node.arguments[0],
+              messageId: 'message',
+            });
+          } else if (node.arguments[0].type === AST_NODE_TYPES.TemplateLiteral) {
+            const source = context.getSourceCode().getText(node.arguments[0]);
+            if (source.includes('"'))
+              context.report({
+                node: node.arguments[0],
+                messageId: 'message',
+              });
+          }
+        }
+      },
+    };
+  },
+});

--- a/test/rules/no-execCmd-double-quotes.test.ts
+++ b/test/rules/no-execCmd-double-quotes.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { noExecCmdDoubleQuotes } from '../../src/rules/no-execCmd-double-quotes';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('call getConnection with version', noExecCmdDoubleQuotes, {
+  valid: [
+    {
+      name: 'single quotes in literal',
+      code: 'execCmd("foo bar \'arg with space\'")',
+    },
+
+    {
+      name: 'single quotes in template literal',
+      code: "execCmd(`foo bar 'arg with space' ${templateProp}`)",
+    },
+  ],
+  invalid: [
+    {
+      name: 'doublequotes in a string literal',
+      errors: [
+        {
+          messageId: 'message',
+        },
+      ],
+      code: 'execCmd(\'foo bar "arg with space"\')',
+    },
+    {
+      name: 'doublequotes in a template literal',
+      errors: [
+        {
+          messageId: 'message',
+        },
+      ],
+      code: 'execCmd(`foo bar "arg with space" ${templateProp}`)',
+    },
+  ],
+});


### PR DESCRIPTION
prevent windows NUT failures by preventing the use of double quotes in execCmd
@W-12423202@