### PR TITLE
Wr/spread base flags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import { noMessagesLoad } from './rules/no-messages-load';
 import { esmMessageImport } from './rules/esm-message-import';
 import { noDefaultDependsOnFlags } from "./rules/no-default-depends-on-flags";
 import { onlyExtendSfCommand } from "./rules/only-extend-sfCommand";
+import { spreadBaseFlags } from "./rules/spread-base-flags";
 
 const library = {
   plugins: ['sf-plugin'],
@@ -88,6 +89,7 @@ const recommended = {
     'sf-plugin/no-classes-in-command-return-type': 'error',
     'sf-plugin/no-default-and-depends-on-flags': 'error',
     'sf-plugin/only-extend-SfCommand': 'warn',
+    'sf-plugin/spread-base-flags': 'error',
   },
 };
 
@@ -113,6 +115,7 @@ export = {
         'sf-plugin/no-username-properties': 'error',
         'sf-plugin/no-default-and-depends-on-flags': 'error',
         'sf-plugin/only-extend-SfCommand': 'warn',
+        'sf-plugin/spread-base-flags': 'error',
       },
     },
   },
@@ -121,6 +124,7 @@ export = {
     'no-h-short-char': dashH,
     'no-default-and-depends-on-flags': noDefaultDependsOnFlags,
     'only-extend-SfCommand': onlyExtendSfCommand,
+    'spread-base-flags': spreadBaseFlags,
     'no-duplicate-short-characters': noDuplicateShortCharacters,
     'run-matches-class-type': runMatchesClassType,
     'flag-case': flagCasing,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { noClassesInCommandReturnType } from './rules/no-classes-in-command-retu
 import { noExecCmdDoubleQuotes } from './rules/no-execCmd-double-quotes';
 import { noMessagesLoad } from './rules/no-messages-load';
 import { esmMessageImport } from './rules/esm-message-import';
+import { noDefaultDependsOnFlags } from "./rules/no-default-depends-on-flags";
 
 const library = {
   plugins: ['sf-plugin'],
@@ -84,6 +85,7 @@ const recommended = {
     'sf-plugin/no-args-parse-without-strict-false': 'error',
     'sf-plugin/no-hyphens-aliases': 'error',
     'sf-plugin/no-classes-in-command-return-type': 'error',
+    'sf-plugin/no-default-and-depends-on-flags': 'error',
   },
 };
 
@@ -107,6 +109,7 @@ export = {
         'sf-plugin/no-time-flags': 'error',
         'sf-plugin/no-id-flags': 'error',
         'sf-plugin/no-username-properties': 'error',
+        'sf-plugin/no-default-and-depends-on-flags': 'error',
         'sf-plugin/encourage-alias-deprecation': 'warn',
       },
     },
@@ -114,6 +117,7 @@ export = {
   rules: {
     'esm-message-import': esmMessageImport,
     'no-h-short-char': dashH,
+    'no-default-and-depends-on-flags': noDefaultDependsOnFlags,
     'no-duplicate-short-characters': noDuplicateShortCharacters,
     'run-matches-class-type': runMatchesClassType,
     'flag-case': flagCasing,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { noExecCmdDoubleQuotes } from './rules/no-execCmd-double-quotes';
 import { noMessagesLoad } from './rules/no-messages-load';
 import { esmMessageImport } from './rules/esm-message-import';
 import { noDefaultDependsOnFlags } from "./rules/no-default-depends-on-flags";
+import { onlyExtendSfCommand } from "./rules/only-extend-sfCommand";
 
 const library = {
   plugins: ['sf-plugin'],
@@ -86,6 +87,7 @@ const recommended = {
     'sf-plugin/no-hyphens-aliases': 'error',
     'sf-plugin/no-classes-in-command-return-type': 'error',
     'sf-plugin/no-default-and-depends-on-flags': 'error',
+    'sf-plugin/only-extend-SfCommand': 'warn',
   },
 };
 
@@ -110,7 +112,7 @@ export = {
         'sf-plugin/no-id-flags': 'error',
         'sf-plugin/no-username-properties': 'error',
         'sf-plugin/no-default-and-depends-on-flags': 'error',
-        'sf-plugin/encourage-alias-deprecation': 'warn',
+        'sf-plugin/only-extend-SfCommand': 'warn',
       },
     },
   },
@@ -118,6 +120,7 @@ export = {
     'esm-message-import': esmMessageImport,
     'no-h-short-char': dashH,
     'no-default-and-depends-on-flags': noDefaultDependsOnFlags,
+    'only-extend-SfCommand': onlyExtendSfCommand,
     'no-duplicate-short-characters': noDuplicateShortCharacters,
     'run-matches-class-type': runMatchesClassType,
     'flag-case': flagCasing,

--- a/src/rules/no-default-depends-on-flags.ts
+++ b/src/rules/no-default-depends-on-flags.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+import { ancestorsContainsSfCommand, isInCommandDirectory } from '../shared/commands';
+import { flagPropertyIsNamed, isFlag } from '../shared/flags';
+
+export const noDefaultDependsOnFlags = RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'Do not allow creation of a flag with default value and dependsOn',
+      recommended: 'recommended',
+    },
+    messages: {
+      message: 'Cannot create a flag with a default value and dependsOn',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return isInCommandDirectory(context)
+      ? {
+        Property(node): void {
+          // is a flag
+          if (
+            isFlag(node) &&
+            ancestorsContainsSfCommand(context.getAncestors()) &&
+            node.value?.type === AST_NODE_TYPES.CallExpression &&
+            node.value.arguments?.[0]?.type === AST_NODE_TYPES.ObjectExpression
+          ) {
+            const dependsOn = node.value.arguments[0].properties.find(
+              (property) =>
+                property.type === AST_NODE_TYPES.Property &&
+                flagPropertyIsNamed(property, 'dependsOn')
+            );
+            const defaultValue = node.value.arguments[0].properties.find(
+              (property) =>
+                property.type === AST_NODE_TYPES.Property &&
+                flagPropertyIsNamed(property, 'default')
+            );
+            if (dependsOn && defaultValue) {
+              context.report({
+                node: dependsOn,
+                messageId: 'message',
+              });
+            }
+          }
+        },
+      }
+      : {};
+  },
+});

--- a/src/rules/only-extend-sfCommand.ts
+++ b/src/rules/only-extend-sfCommand.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+  isInCommandDirectory,
+  extendsSfCommand,
+} from "../shared/commands";
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+
+export const onlyExtendSfCommand = RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'Only allow commands that directly extend SfCommand',
+      recommended: 'recommended',
+    },
+    messages: {
+      message: 'In order to inherit default flags correctly, extend from SfCommand directly',
+    },
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return isInCommandDirectory(context)
+      ? {
+        ClassDeclaration(node): void {
+          // verify it extends SfCommand
+          if (!extendsSfCommand(node) && node.id) {
+              context.report({
+                node: node.id,
+                messageId: 'message',
+              });
+          }
+        },
+      }
+      : {};
+  },
+});

--- a/src/rules/spread-base-flags.ts
+++ b/src/rules/spread-base-flags.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { isInCommandDirectory, ancestorsContainsSfCommand, getSfCommand } from '../shared/commands';
+import { RuleCreator } from '@typescript-eslint/utils/eslint-utils';
+import { getFlagsStaticPropertyFromCommandClass, isFlagsStaticProperty } from '../shared/flags';
+import { ASTUtils, AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+
+export const spreadBaseFlags = RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description:
+        'When not directly extending SfCommand, baseFlags must be spread like Flags = {...<super>.baseFlags}',
+      recommended: 'recommended',
+    },
+    messages: {
+      message: 'When not directly extending SfCommand, baseFlags must be spread like Flags = {...<super>.baseFlags}',
+    },
+    type: 'problem',
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return isInCommandDirectory(context)
+      ? {
+          ClassDeclaration(node): void {
+            const flagsProperty = getFlagsStaticPropertyFromCommandClass(node);
+            if (!flagsProperty) return;
+            // @ts-ignore
+            const flag = flagsProperty.value?.properties?.find((f) => f.type === 'SpreadElement');
+
+            if (!ancestorsContainsSfCommand(context.getAncestors()) && !flag) {
+              context.report({
+                loc: flagsProperty.loc,
+                messageId: 'message',
+              });
+            }
+          },
+        }
+      : {};
+  },
+});

--- a/src/rules/spread-base-flags.ts
+++ b/src/rules/spread-base-flags.ts
@@ -13,14 +13,14 @@ export const spreadBaseFlags = RuleCreator.withoutDocs({
   meta: {
     docs: {
       description:
-        'When not directly extending SfCommand, baseFlags must be spread like Flags = {...<super>.baseFlags}',
+        "When not directly extending SfCommand, the parent's flags must be spread like flags = {...{{parent}}.flags}",
       recommended: 'recommended',
     },
     messages: {
-      message: 'When not directly extending SfCommand, baseFlags must be spread like Flags = {...<super>.baseFlags}',
+      message:
+        "When not directly extending SfCommand, the parent's flags must be spread like flags = {...{{parent}}.flags}",
     },
     type: 'problem',
-    fixable: 'code',
     schema: [],
   },
   defaultOptions: [],
@@ -37,6 +37,8 @@ export const spreadBaseFlags = RuleCreator.withoutDocs({
               context.report({
                 loc: flagsProperty.loc,
                 messageId: 'message',
+                // @ts-ignore name will not be undefined because we're in a command class, which has to at least extend Command
+                data: { parent: node.superClass?.name },
               });
             }
           },

--- a/test/rules/no-default-depends-on-flags.test.ts
+++ b/test/rules/no-default-depends-on-flags.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'path';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { noDefaultDependsOnFlags } from "../../src/rules/no-default-depends-on-flags";
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('noDefaultDependsOnFlags', noDefaultDependsOnFlags, {
+  valid: [
+    {
+      name: 'does not use default and dependsOn',
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    alias: Flags.string({
+      summary: 'foo',
+      char: 'a'
+    })
+  }
+}
+
+`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'uses dependsOn and default',
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [{ messageId: 'message' }],
+      code: `
+export default class EnvCreateScratch extends SfCommand<Foo> {
+  public static flags = {
+    json: Flags.boolean({
+      char: 'h',
+      default: true,
+      dependsOn: ['myOtherFlag']
+    })
+  }
+}
+`,
+    },
+  ],
+});

--- a/test/rules/only-extend-sfCommand.test.ts
+++ b/test/rules/only-extend-sfCommand.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'path';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { onlyExtendSfCommand } from "../../src/rules/only-extend-sfCommand";
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('only-extend-SfCommand', onlyExtendSfCommand, {
+  valid: [
+    {
+      name: 'extends SfCommand directly',
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class EnvCreateScratch extends SfCommand<ScratchCreateResponse> {
+  public static flags = {
+    alias: Flags.string({
+      summary: 'foo',
+      char: 'a'
+    })
+  }
+}
+
+`,
+    },
+    {
+      name: 'not a command, can extend something else',
+      filename: path.normalize('src/base/foo.ts'),
+      code: `
+export default class MyFormatter extends Formatter {
+}
+
+`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'does not extend SfCommand directly',
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [{ messageId: 'message' }],
+      code: `
+export default class EnvCreateScratch extends BaseCommand<Foo> {
+  public static flags = {
+    json: Flags.boolean({
+      char: 'h',
+      default: true,
+      dependsOn: ['myOtherFlag']
+    })
+  }
+}
+`,
+    },
+  ],
+});

--- a/test/rules/spread-base-flags.test.ts
+++ b/test/rules/spread-base-flags.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import path from 'path';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { spreadBaseFlags } from '../../src/rules/spread-base-flags';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('spread-base-flags', spreadBaseFlags, {
+  valid: [
+    {
+      name: 'spreads base flags when required',
+      filename: path.normalize('src/commands/foo.ts'),
+      code: `
+export default class Top extends Base<ScratchCreateResponse> {
+  public static flags = {
+    ...Base.flags,
+    alias: Flags.string({
+      summary: 'foo',
+      char: 'a'
+    })
+  }
+}
+`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'does not spread base flags',
+      filename: path.normalize('src/commands/foo.ts'),
+      errors: [{ messageId: 'message' }],
+      code: `
+export default class Top extends BaseCommand<Foo> {
+  public static flags = {
+    json: Flags.boolean({
+      char: 'h',
+      default: true,
+      dependsOn: ['myOtherFlag']
+    })
+  }
+}
+`,
+    },
+  ],
+});


### PR DESCRIPTION

@W-15837411@

warning to encourage inheriting from `SfCommand` directly
```bash
/Users/william.ruemmele/projects/oss/plugin-devops-center/src/commands/project/deploy/pipeline/report.ts
  15:22  warning  In order to inherit default flags correctly, extend from SfCommand directly                          sf-plugin/only-extend-SfCommand
```

error when not spreading parent class' flags
```bash
  20:3   error            When not directly extending SfCommand, the parent's flags must be spread like flags = {...ReportOnPromoteCommand.flags}
  sf-plugin/spread-base-flags
```